### PR TITLE
docs: update math rendering option

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,8 +1,7 @@
 url: https://aaoritz.github.io/nuts/
 template:
   bootstrap: 5
-  params:
-    mathjax: true
+  math-rendering: mathjax
 home:
   title: Convert European Regional Data in R
 reference:


### PR DESCRIPTION
rotemplate is now aligned with https://pkgdown.r-lib.org/articles/customise.html#math-rendering